### PR TITLE
Update InvalidTokenmanagerComponent

### DIFF
--- a/src/exceptions/InvalidTokenmanagerComponent.php
+++ b/src/exceptions/InvalidTokenmanagerComponent.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace dmstr\tokenManager\exceptions;
 
 class InvalidTokenManagerComponent extends \Exception


### PR DESCRIPTION
Removed strict type declaration as it is not used in any other file and could lead to inconsistent behavior if not used in every file